### PR TITLE
moved kableExtra to conda to fix failed install with R install.packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,9 @@ RUN apt update && \
     apt install -y texlive-full lmodern libbz2-dev nano && \
     apt clean
 
-RUN R -e "install.packages(c('DT', 'GGally', 'kableExtra', 'mosaic', 'mosaicCore', 'MosaicData', 'openintro', 'palmerpenguins', 'cherryblossom', 'network', 'fivethirtyeight', 'Lock5Data', 'learnr', 'skimr', 'tutorial.helpers'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+RUN conda install -y conda-forge::r-kableextra
+
+RUN R -e "install.packages(c('DT', 'GGally', 'mosaic', 'mosaicCore', 'MosaicData', 'openintro', 'palmerpenguins', 'cherryblossom', 'network', 'fivethirtyeight', 'Lock5Data', 'learnr', 'skimr', 'tutorial.helpers'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 RUN R -e 'devtools::install_github("hadley/emo")'
 


### PR DESCRIPTION
Have to install kableExtra with conda-forge now instead of R for some reason (Ubuntu move header files around?).